### PR TITLE
Remove unused compatibility imports

### DIFF
--- a/postmarker/_compat.py
+++ b/postmarker/_compat.py
@@ -8,12 +8,6 @@ except ImportError:  # Python 2.7
 
 
 try:
-    from unittest.mock import patch
-except ImportError:  # Python < 3.3
-    from mock import patch  # noqa
-
-
-try:
     from inspect import signature
 
     def get_args(cls):


### PR DESCRIPTION
These imports are defined in tests/_compat.py and used only in tests.

Fixes issue #158.