### PR TITLE
Django email backend metadata support. Closes #180

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -45,7 +45,7 @@ To globally turn on ``TrackOpens`` feature, set ``TRACK_OPENS`` to ``True``.
 Messages
 ========
 
-To mark messages with tags you could use ``postmarker.django.PostmarkEmailMessage`` /  ``postmarker.django.PostmarkEmailMultiAlternatives``
+To mark messages with tags and / or add metadata, you could use ``postmarker.django.PostmarkEmailMessage`` /  ``postmarker.django.PostmarkEmailMultiAlternatives``
 instead of ``EmailMessage`` / ``EmailMultiAlternatives`` from Django.
 Example:
 
@@ -54,7 +54,11 @@ Example:
     >>> from postmarker.django import PostmarkEmailMessage
     >>> PostmarkEmailMessage(
         'Subject', 'Body', 'sender@example.com', ['receiver@example.com'],
-        tag='Test tag'
+        tag='Test tag',
+        metadata={
+            "color":"blue",
+            "client-id":"12345",
+        },
     ).send()
 
 You can get the same feature for your own classes with ``PostmarkEmailMixin``.

--- a/postmarker/django/backend.py
+++ b/postmarker/django/backend.py
@@ -87,6 +87,7 @@ class EmailBackend(BaseEmailBackend):
     def prepare_message(self, message):
         instance = message.message()
         instance.tag = getattr(message, "tag", None)
+        instance.metadata = getattr(message, "metadata", None)
         if message.bcc:
             instance["Bcc"] = ", ".join(map(force_text, message.bcc))
         return instance
@@ -99,6 +100,7 @@ class PostmarkEmailMixin(object):
 
     def __init__(self, *args, **kwargs):
         self.tag = kwargs.pop("tag", None)
+        self.metadata = kwargs.pop("metadata", None)
         super(PostmarkEmailMixin, self).__init__(*args, **kwargs)
 
 

--- a/postmarker/models/emails.py
+++ b/postmarker/models/emails.py
@@ -195,6 +195,7 @@ class Email(BaseEmail):
         bcc = prepare_header(message["Bcc"])
         reply_to = prepare_header(message["Reply-To"])
         tag = getattr(message, "tag", None)
+        metadata = getattr(message, "metadata", None)
         return cls(
             manager=manager,
             From=sender,
@@ -207,6 +208,7 @@ class Email(BaseEmail):
             ReplyTo=reply_to,
             Attachments=attachments,
             Tag=tag,
+            Metadata=metadata,
         )
 
     def send(self):

--- a/tests/django/test_backend.py
+++ b/tests/django/test_backend.py
@@ -49,6 +49,7 @@ def test_send_mail(postmark_request, settings):
             "TextBody": "Here is the message.",
             "HtmlBody": None,
             "Tag": None,
+            "Metadata": None,
             "TrackOpens": False,
             "From": "sender@example.com",
         },
@@ -166,6 +167,7 @@ def test_send_mail_with_attachment(postmark_request, message):
         "Cc": None,
         "Bcc": None,
         "Tag": None,
+        "Metadata": None,
     }
 
 
@@ -194,6 +196,7 @@ def test_text_html_alternative_and_pdf_attachment_failure(postmark_request, mess
         "ReplyTo": None,
         "Subject": "subject",
         "Tag": None,
+        "Metadata": None,
         "TextBody": "text_content",
         "To": "receiver@example.com",
         "TrackOpens": False,
@@ -219,6 +222,7 @@ def test_message_rfc822(postmark_request, message):
         "ReplyTo": None,
         "Subject": "subject",
         "Tag": None,
+        "Metadata": None,
         "TextBody": "text_content",
         "To": "receiver@example.com",
         "TrackOpens": False,
@@ -272,6 +276,7 @@ def test_send_mail_html_message(html_message, postmark_request):
             "HtmlBody": html_message,
             "TrackOpens": False,
             "Tag": None,
+            "Metadata": None,
             "From": "sender@example.com",
         },
     )
@@ -295,6 +300,7 @@ def test_send_long_text_line(postmark_request):
             "HtmlBody": None,
             "TrackOpens": False,
             "Tag": None,
+            "Metadata": None,
             "From": "sender@example.com",
         },
     )
@@ -328,6 +334,7 @@ def test_extra_options(settings, postmark_request):
             "TextBody": "Here is the message.",
             "HtmlBody": None,
             "Tag": None,
+            "Metadata": None,
             "TrackOpens": True,
             "From": "sender@example.com",
         },
@@ -350,6 +357,7 @@ def test_context_manager(postmark_request):
             "TextBody": "Body",
             "HtmlBody": None,
             "Tag": None,
+            "Metadata": None,
             "TrackOpens": True,
             "From": "sender@example.com",
         },
@@ -399,6 +407,7 @@ class TestSignals:
             "ReplyTo": None,
             "Subject": "Subject here",
             "Tag": None,
+            "Metadata": None,
             "TextBody": "Here is the message.",
             "To": "receiver@example.com",
         }

--- a/tests/django/test_mixins.py
+++ b/tests/django/test_mixins.py
@@ -26,5 +26,35 @@ def test_tags(postmark_request):
         "HtmlBody": None,
         "TrackOpens": True,
         "Tag": "Test tag",
+        "Metadata": None,
+        "From": "sender@example.com",
+    }
+
+
+class EmailWithMetadata(PostmarkEmailMixin, EmailMultiAlternatives):
+    pass
+
+
+def test_metadata(postmark_request):
+    EmailWithMetadata(
+        "Subject", "Body", "sender@example.com", ["receiver@example.com"],
+        metadata={"key1": "value1", "key2": "value2"}
+    ).send()
+    assert postmark_request.call_args[1]["json"][0] == {
+        "ReplyTo": None,
+        "Subject": "Subject",
+        "To": "receiver@example.com",
+        "Bcc": None,
+        "Headers": [],
+        "Cc": None,
+        "Attachments": [],
+        "TextBody": "Body",
+        "HtmlBody": None,
+        "TrackOpens": True,
+        "Tag": None,
+        "Metadata": {
+            "key1": "value1",
+            "key2": "value2",
+        },
         "From": "sender@example.com",
     }

--- a/tests/django/test_mixins.py
+++ b/tests/django/test_mixins.py
@@ -37,8 +37,7 @@ class EmailWithMetadata(PostmarkEmailMixin, EmailMultiAlternatives):
 
 def test_metadata(postmark_request):
     EmailWithMetadata(
-        "Subject", "Body", "sender@example.com", ["receiver@example.com"],
-        metadata={"key1": "value1", "key2": "value2"}
+        "Subject", "Body", "sender@example.com", ["receiver@example.com"], metadata={"key1": "value1", "key2": "value2"}
     ).send()
     assert postmark_request.call_args[1]["json"][0] == {
         "ReplyTo": None,
@@ -52,9 +51,6 @@ def test_metadata(postmark_request):
         "HtmlBody": None,
         "TrackOpens": True,
         "Tag": None,
-        "Metadata": {
-            "key1": "value1",
-            "key2": "value2",
-        },
+        "Metadata": {"key1": "value1", "key2": "value2"},
         "From": "sender@example.com",
     }

--- a/tests/models/test_emails.py
+++ b/tests/models/test_emails.py
@@ -170,6 +170,7 @@ class TestSimpleSend:
             "Subject": "Test subject",
             "TextBody": "Text",
             "Tag": None,
+            "Metadata": None,
             "To": "receiver@example.com",
         }
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@ deps =
     requests
     pytest<3.3
     pytest-django<3.0.0
-    pytest-tornado
+    pytest-tornado<0.6
     coverage
     betamax
     betamax_serializers
-    py27,pypy,pypy3,py33,py34,py35,py36: tornado>4.0.0,<5.0
+    py27,pypy,pypy3,py33,py34,py35,py36,py37: tornado>4.0.0,<5.0
     py27,pypy: mock
     py27,pypy,py34,py35: Django>=1.10.0,<1.11.0
     py36: Django>=1.11.0,<2.0.0


### PR DESCRIPTION
* Add metadata support to `postmarker.django.EmailBackend`
* Add test for email with metadata
* Update docs
* Fix `tox.ini`: specify versions of packages