### PR TITLE
Update domains verification methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 .ropeproject
 
 .idea/
+.vscode/

--- a/postmarker/models/domains.py
+++ b/postmarker/models/domains.py
@@ -21,6 +21,12 @@ class Domain(Model):
     def verifyspf(self):
         return self._manager.verifyspf(self.ID)
 
+    def verifydkim(self):
+        return self._manager.verifydkim(self.ID)
+
+    def verifyreturnpath(self):
+        return self._manager.verifyreturnpath(self.ID)
+
     def rotatedkim(self):
         return self._manager.rotatedkim(self.ID)
 
@@ -51,6 +57,12 @@ class DomainsManager(ModelManager):
 
     def verifyspf(self, id):
         return self.call("POST", "/domains/%s/verifyspf" % id)
+
+    def verifydkim(self, id):
+        return self.call("PUT", "/domains/%s/verifyDkim" % id)
+
+    def verifyreturnpath(self, id):
+        return self.call("PUT", "/domains/%s/verifyReturnPath" % id)
 
     def rotatedkim(self, id):
         return self.call("POST", "/domains/%s/rotatedkim" % id)

--- a/tests/cassettes/domains.json
+++ b/tests/cassettes/domains.json
@@ -1,6 +1,5 @@
 {
-  "http_interactions": [
-    {
+  "http_interactions": [{
       "recorded_at": "2016-12-04T20:21:59",
       "request": {
         "body": {
@@ -354,7 +353,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAEAB3KuwrDMAxG4Vcxmoshq6Fr6FhoyC7q32CQlRDZaaC0z57L+p3zpdezH7HklBEpJBbD7bTHZJUCKT7WZixxKpzVKxfQ1QdsdWRpOKb1bnPqHLuyuaxvaRHhEF8q2+oV1f1ZhH47a719C20AAAA=",
+          "base64_string": "H4sIALcQ1F0C/x3KwQqDMBBF0V8Js5ZAtwG3pctCi/vBPCGQjJJMVBD77Y1uz70Hfd7PATlMAZ6c5oruotdclBwJtlIXZD8nDmKFE+juX+w6cKxo09qXZXoYNmk3QcZYPVwTm5TLagVqfhwjnX/4K8htbAAAAA==",
           "encoding": "utf-8"
         },
         "headers": {
@@ -385,6 +384,136 @@
           "message": "OK"
         },
         "url": "https://api.postmarkapp.com/domains/386143/verifyspf"
+      }
+    },
+    {
+      "recorded_at": "2016-12-05T08:18:51",
+      "request": {
+        "body": {
+          "base64_string": "",
+          "encoding": "utf-8"
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "User-Agent": [
+            "Postmarker/0.6.0.dev"
+          ],
+          "X-Postmark-Account-Token": [
+            "ACCOUNT_TOKEN"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.postmarkapp.com/domains/386143/verifyDkim"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIABET1F0C/31SyXKbMBh+FcbXdhwWm5B0fMCAMcMSFi91Lh0RhCEgAUIQQ6d99prEzjhum6M+fcu//Rw5AMHRPTPC8KVuSkiiAoEUj/EAf2VGgbvYQJLGKYyOLEoa+AYui5p+LlvBA92AvHl1b2d1GXMMYNCBSfFT3kTw/oiMEQV1O8aQMr9Bng9K1TTsi8QY5PUQuYUgG74uoOF5LuOs/BB6Bl2IoxTvz1ye5USOZ6fcdMrzUonGP96Kz2A3/k87Fy4fErIZqcG3cmYbemzLrK4ElR4YoaB62lz21rI80R1ZVeapZ873ntKFfSCSbRXfLVd73EWmYn15ecjQzk7rsPWMtWXvtI3oV7TnaHHL+QuNNHwkRK7BsoK+mFgxARKXhDIl+/LuMePa2zkIe5SYhqysUuwQywGaKWgPPecXgtLTmypgrSRoUlOKkq0robSfPD7dbLq+wlmyXYbfpV1z0LZxq1vas9uKHX3O+alnqLInz8+9+7AtMhhdT/sE/zX0AMRwVfgQFS08cUzYLUiBVCe42uC6jACFAQW0qQf9acyDjQ9pQ7ALaKK+ruOTe7um/uOCrimKI9vae9nHM3i/xcHQUI+oIIncRPj1B+pGeXQlAwAA",
+          "encoding": "utf-8"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "119"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Mon, 05 Dec 2016 08:18:51 GMT"
+          ],
+          "Server": [
+            "unicorns-double-rainbow"
+          ],
+          "X-Powered-By": [
+            "ASP.NET"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.postmarkapp.com/domains/386143/verifyDkim"
+      }
+    },
+    {
+      "recorded_at": "2016-12-05T08:18:51",
+      "request": {
+        "body": {
+          "base64_string": "",
+          "encoding": "utf-8"
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "User-Agent": [
+            "Postmarker/0.6.0.dev"
+          ],
+          "X-Postmark-Account-Token": [
+            "ACCOUNT_TOKEN"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.postmarkapp.com/domains/386143/verifyReturnPath"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIABET1F0C/31SyXKbMBh+FcbXdhwWm5B0fMCAMcMSFi91Lh0RhCEgAUIQQ6d99prEzjhum6M+fcu//Rw5AMHRPTPC8KVuSkiiAoEUj/EAf2VGgbvYQJLGKYyOLEoa+AYui5p+LlvBA92AvHl1b2d1GXMMYNCBSfFT3kTw/oiMEQV1O8aQMr9Bng9K1TTsi8QY5PUQuYUgG74uoOF5LuOs/BB6Bl2IoxTvz1ye5USOZ6fcdMrzUonGP96Kz2A3/k87Fy4fErIZqcG3cmYbemzLrK4ElR4YoaB62lz21rI80R1ZVeapZ873ntKFfSCSbRXfLVd73EWmYn15ecjQzk7rsPWMtWXvtI3oV7TnaHHL+QuNNHwkRK7BsoK+mFgxARKXhDIl+/LuMePa2zkIe5SYhqysUuwQywGaKWgPPecXgtLTmypgrSRoUlOKkq0robSfPD7dbLq+wlmyXYbfpV1z0LZxq1vas9uKHX3O+alnqLInz8+9+7AtMhhdT/sE/zX0AMRwVfgQFS08cUzYLUiBVCe42uC6jACFAQW0qQf9acyDjQ9pQ7ALaKK+ruOTe7um/uOCrimKI9vae9nHM3i/xcHQUI+oIIncRPj1B+pGeXQlAwAA",
+          "encoding": "utf-8"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "119"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Mon, 05 Dec 2016 08:18:51 GMT"
+          ],
+          "Server": [
+            "unicorns-double-rainbow"
+          ],
+          "X-Powered-By": [
+            "ASP.NET"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.postmarkapp.com/domains/386143/verifyReturnPath"
       }
     },
     {

--- a/tests/models/test_domains.py
+++ b/tests/models/test_domains.py
@@ -30,7 +30,47 @@ class TestManager:
         assert domain.verifyspf() == {
             "SPFHost": "newsuperdomain.name",
             "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
-            "SPFVerified": False,
+            "SPFVerified": True,
+        }
+        assert domain.verifydkim() == {
+            "Name": "newsuperdomain.name",
+            "SPFVerified": True,
+            "SPFHost": "newsuperdomain.name",
+            "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+            "DKIMVerified": False,
+            "WeakDKIM": False,
+            "DKIMHost": "",
+            "DKIMTextValue": "",
+            "DKIMPendingHost": "20161205155228pm._domainkey.newsuperdomain.name",
+            "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCybzS6rWqf9HTgnydKCL+wOkmYMisbvQIULMYEV6Rqtz1to71RFEru2d3dPI003GF4Lfra81hbAtrgp9Zk1v7BabzmhKIACTinNrLNaEK3EOz1Ro3Czt/qS0LhSuiK8dhWP8miz4Zc/VyzqnkhWHbX8YuxEWfvGLEjPv6ytjl25QIDAQAB",
+            "DKIMRevokedHost": "",
+            "DKIMRevokedTextValue": "",
+            "SafeToRemoveRevokedKeyFromDNS": False,
+            "DKIMUpdateStatus": "Pending",
+            "ReturnPathDomain": "newsuperdomain.name",
+            "ReturnPathDomainVerified": False,
+            "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+            "ID": 386143,
+        }
+        assert domain.verifyreturnpath() == {
+            "Name": "newsuperdomain.name",
+            "SPFVerified": True,
+            "SPFHost": "newsuperdomain.name",
+            "SPFTextValue": "v=spf1 a mx include:spf.mtasv.net ~all",
+            "DKIMVerified": False,
+            "WeakDKIM": False,
+            "DKIMHost": "",
+            "DKIMTextValue": "",
+            "DKIMPendingHost": "20161205155228pm._domainkey.newsuperdomain.name",
+            "DKIMPendingTextValue": "k=rsa;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCybzS6rWqf9HTgnydKCL+wOkmYMisbvQIULMYEV6Rqtz1to71RFEru2d3dPI003GF4Lfra81hbAtrgp9Zk1v7BabzmhKIACTinNrLNaEK3EOz1Ro3Czt/qS0LhSuiK8dhWP8miz4Zc/VyzqnkhWHbX8YuxEWfvGLEjPv6ytjl25QIDAQAB",
+            "DKIMRevokedHost": "",
+            "DKIMRevokedTextValue": "",
+            "SafeToRemoveRevokedKeyFromDNS": False,
+            "DKIMUpdateStatus": "Pending",
+            "ReturnPathDomain": "newsuperdomain.name",
+            "ReturnPathDomainVerified": False,
+            "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+            "ID": 386143,
         }
         with pytest.raises(ClientError) as exc:
             assert domain.rotatedkim()


### PR DESCRIPTION
Postmark deprecated verifyspf (see https://postmarkapp.com/blog/why-we-no-longer-ask-for-spf-records).

This PR:
* Updates the test case for verifyspf to reflect this (ie. SPFVerified is always True)
* Introduces 2 new methods for verifyDkim and verifyReturnPath API endpoints