### PR TITLE
Allow EmailTemplate() to accept metadata parameters

### DIFF
--- a/postmarker/models/emails.py
+++ b/postmarker/models/emails.py
@@ -398,7 +398,7 @@ class EmailManager(ModelManager):
             TrackLinks=TrackLinks,
             Attachments=Attachments,
             InlineCss=InlineCss,
-            Metadata=Metadata
+            Metadata=Metadata,
         ).send()
 
     def send_batch(self, *emails, **extra):

--- a/postmarker/models/emails.py
+++ b/postmarker/models/emails.py
@@ -380,6 +380,7 @@ class EmailManager(ModelManager):
         TrackLinks="None",
         Attachments=None,
         InlineCss=True,
+        Metadata=None,
     ):
         return self.EmailTemplate(
             TemplateId=TemplateId,
@@ -397,6 +398,7 @@ class EmailManager(ModelManager):
             TrackLinks=TrackLinks,
             Attachments=Attachments,
             InlineCss=InlineCss,
+            Metadata=Metadata
         ).send()
 
     def send_batch(self, *emails, **extra):
@@ -467,6 +469,7 @@ class EmailManager(ModelManager):
         TrackLinks="None",
         Attachments=None,
         InlineCss=True,
+        Metadata=None,
     ):
         """
         Constructs :py:class:`EmailTemplate` instance.
@@ -490,6 +493,7 @@ class EmailManager(ModelManager):
             TrackLinks=TrackLinks,
             Attachments=Attachments,
             InlineCss=InlineCss,
+            Metadata=Metadata,
         )
 
     def EmailBatch(self, *emails):


### PR DESCRIPTION

EmailTemplate() now accept Metadata parameters.

e.g.
```
postmark.emails.EmailTemplate(
	TemplateId=template_id,
	TemplateAlias=template_alias,
	From=f"{from_name} {from_}",
	To=user.email,
	Headers={"X-Accept-Language": "en-us, en"},
	TemplateModel=template_model,
	Metadata=metadata
)
```