### PR TITLE
Add support for Postmark API "MessageStream" option

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -41,7 +41,7 @@ To globally turn on ``TrackOpens`` feature, set ``TRACK_OPENS`` to ``True``.
 Messages
 ========
 
-To mark messages with tags and / or add metadata, you could use ``postmarker.django.PostmarkEmailMessage`` /  ``postmarker.django.PostmarkEmailMultiAlternatives``
+To mark messages with tags, add metadata, or specify the message stream, you could use ``postmarker.django.PostmarkEmailMessage`` /  ``postmarker.django.PostmarkEmailMultiAlternatives``
 instead of ``EmailMessage`` / ``EmailMultiAlternatives`` from Django.
 Example:
 
@@ -55,6 +55,7 @@ Example:
             "color":"blue",
             "client-id":"12345",
         },
+        message_stream="example-message-stream"
     ).send()
 
 You can get the same feature for your own classes with ``PostmarkEmailMixin``.

--- a/src/postmarker/django/backend.py
+++ b/src/postmarker/django/backend.py
@@ -80,6 +80,7 @@ class EmailBackend(BaseEmailBackend):
         instance = message.message()
         instance.tag = getattr(message, "tag", None)
         instance.metadata = getattr(message, "metadata", None)
+        instance.message_stream = getattr(message, "message_stream", None)
         if message.bcc:
             instance["Bcc"] = ", ".join(map(force_text, message.bcc))
         return instance
@@ -91,6 +92,7 @@ class PostmarkEmailMixin:
     def __init__(self, *args, **kwargs):
         self.tag = kwargs.pop("tag", None)
         self.metadata = kwargs.pop("metadata", None)
+        self.message_stream = kwargs.pop("message_stream", None)
         super().__init__(*args, **kwargs)
 
 

--- a/src/postmarker/models/emails.py
+++ b/src/postmarker/models/emails.py
@@ -192,6 +192,7 @@ class Email(BaseEmail):
         reply_to = prepare_header(message["Reply-To"])
         tag = getattr(message, "tag", None)
         metadata = getattr(message, "metadata", None)
+        message_stream = getattr(message, "message_stream", None)
         return cls(
             manager=manager,
             From=sender,
@@ -205,6 +206,7 @@ class Email(BaseEmail):
             Attachments=attachments,
             Tag=tag,
             Metadata=metadata,
+            MessageStream=message_stream,
         )
 
     def send(self):
@@ -295,6 +297,7 @@ class EmailManager(ModelManager):
         TrackOpens=None,
         TrackLinks="None",
         Attachments=None,
+        MessageStream=None,
     ):
         """Sends a single email.
 
@@ -339,6 +342,7 @@ class EmailManager(ModelManager):
                 TrackOpens=TrackOpens,
                 TrackLinks=TrackLinks,
                 Attachments=Attachments,
+                MessageStream=MessageStream,
             )
         elif isinstance(message, (MIMEText, MIMEMultipart)):
             message = Email.from_mime(message, self)
@@ -364,6 +368,7 @@ class EmailManager(ModelManager):
         Attachments=None,
         InlineCss=True,
         Metadata=None,
+        MessageStream=None,
     ):
         return self.EmailTemplate(
             TemplateId=TemplateId,
@@ -382,6 +387,7 @@ class EmailManager(ModelManager):
             Attachments=Attachments,
             InlineCss=InlineCss,
             Metadata=Metadata,
+            MessageStream=MessageStream,
         ).send()
 
     def send_batch(self, *emails, **extra):
@@ -410,6 +416,7 @@ class EmailManager(ModelManager):
         TrackOpens=None,
         TrackLinks="None",
         Attachments=None,
+        MessageStream=None,
     ):
         """Constructs :py:class:`Email` instance.
 
@@ -431,6 +438,7 @@ class EmailManager(ModelManager):
             TrackOpens=TrackOpens,
             TrackLinks=TrackLinks,
             Attachments=Attachments,
+            MessageStream=MessageStream,
         )
 
     def EmailTemplate(
@@ -451,6 +459,7 @@ class EmailManager(ModelManager):
         Attachments=None,
         InlineCss=True,
         Metadata=None,
+        MessageStream=None,
     ):
         """Constructs :py:class:`EmailTemplate` instance.
 
@@ -474,6 +483,7 @@ class EmailManager(ModelManager):
             Attachments=Attachments,
             InlineCss=InlineCss,
             Metadata=Metadata,
+            MessageStream=MessageStream,
         )
 
     def EmailBatch(self, *emails):

--- a/test/django/test_backend.py
+++ b/test/django/test_backend.py
@@ -50,6 +50,7 @@ def test_send_mail(postmark_request, settings):
             "HtmlBody": None,
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "TrackOpens": False,
             "From": "sender@example.com",
         },
@@ -170,6 +171,7 @@ def test_send_mail_with_attachment(postmark_request, message):
         "Bcc": None,
         "Tag": None,
         "Metadata": None,
+        "MessageStream": None,
     }
 
 
@@ -197,6 +199,7 @@ def test_text_html_alternative_and_pdf_attachment_failure(postmark_request, mess
         "Subject": "subject",
         "Tag": None,
         "Metadata": None,
+        "MessageStream": None,
         "TextBody": "text_content",
         "To": "receiver@example.com",
         "TrackOpens": False,
@@ -225,6 +228,7 @@ def test_message_rfc822(postmark_request, message):
         "Subject": "subject",
         "Tag": None,
         "Metadata": None,
+        "MessageStream": None,
         "TextBody": "text_content",
         "To": "receiver@example.com",
         "TrackOpens": False,
@@ -283,6 +287,7 @@ def test_send_mail_html_message(html_message, postmark_request):
             "TrackOpens": False,
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "From": "sender@example.com",
         },
     )
@@ -307,6 +312,7 @@ def test_send_long_text_line(postmark_request):
             "TrackOpens": False,
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "From": "sender@example.com",
         },
     )
@@ -341,6 +347,7 @@ def test_extra_options(settings, postmark_request):
             "HtmlBody": None,
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "TrackOpens": True,
             "From": "sender@example.com",
         },
@@ -364,6 +371,7 @@ def test_context_manager(postmark_request):
             "HtmlBody": None,
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "TrackOpens": True,
             "From": "sender@example.com",
         },
@@ -414,6 +422,7 @@ class TestSignals:
             "Subject": "Subject here",
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "TextBody": "Here is the message.",
             "To": "receiver@example.com",
         }

--- a/test/django/test_mixins.py
+++ b/test/django/test_mixins.py
@@ -31,6 +31,7 @@ def test_tags(postmark_request):
         "TrackOpens": True,
         "Tag": "Test tag",
         "Metadata": None,
+        "MessageStream": None,
         "From": "sender@example.com",
     }
 
@@ -60,5 +61,32 @@ def test_metadata(postmark_request):
         "TrackOpens": True,
         "Tag": None,
         "Metadata": {"key1": "value1", "key2": "value2"},
+        "MessageStream": None,
+        "From": "sender@example.com",
+    }
+
+
+class EmailWithMessageStream(PostmarkEmailMixin, EmailMultiAlternatives):
+    pass
+
+
+def test_metadata(postmark_request):
+    EmailWithMessageStream(
+        "Subject", "Body", "sender@example.com", ["receiver@example.com"], message_stream="example-message-stream"
+    ).send()
+    assert postmark_request.call_args[1]["json"][0] == {
+        "ReplyTo": None,
+        "Subject": "Subject",
+        "To": "receiver@example.com",
+        "Bcc": None,
+        "Headers": [],
+        "Cc": None,
+        "Attachments": [],
+        "TextBody": "Body",
+        "HtmlBody": None,
+        "TrackOpens": True,
+        "Tag": None,
+        "Metadata": None,
+        "MessageStream": "example-message-stream",
         "From": "sender@example.com",
     }

--- a/test/models/test_emails.py
+++ b/test/models/test_emails.py
@@ -18,7 +18,7 @@ def get_attachment_path(filename):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "attachments/%s" % filename))
 
 
-if platform.system() == "Linux":
+if platform.system() in {"Linux", "Darwin"}:
     RAW_CONTENT = b"test content\n"
 else:
     RAW_CONTENT = b"test content\r\n"
@@ -156,6 +156,11 @@ class TestSimpleSend:
         postmark.emails.send(**minimal_data)
         assert postmark_request.call_args[1]["json"]["Headers"] == [{"Name": "Test", "Value": 1}]
 
+    def test_message_stream(self, postmark, minimal_data, postmark_request):
+        minimal_data["MessageStream"] = "example-message-stream"
+        postmark.emails.send(**minimal_data)
+        assert postmark_request.call_args[1]["json"]["MessageStream"] == "example-message-stream"
+
     @pytest.mark.parametrize("attachment", SUPPORTED_ATTACHMENTS)
     def test_attachments(self, postmark, minimal_data, postmark_request, attachment):
         minimal_data["Attachments"] = [attachment]
@@ -182,6 +187,7 @@ class TestSimpleSend:
             "TextBody": "Text",
             "Tag": None,
             "Metadata": None,
+            "MessageStream": None,
             "To": "receiver@example.com",
         }
 


### PR DESCRIPTION
This PR implements support for passing a `MessageStream` kwarg when sending emails.  Without the `MessageStream` kwarg passed in, Postmark will default to the default transactional message stream.  By passing in a `MessageStream` kwarg with a string value representing the message stream, the consumer of this package can specify a custom message stream to use.

The Postmark API documentation supporting this change can be viewed here: https://postmarkapp.com/developer/user-guide/send-email-with-api

This change was discussed briefly in the `postmarker` Gitter channel: https://gitter.im/Stranger6667/postmarker?at=5fa9ba3c8a236947ba9642ab

Thank you,
Colin