### PR TITLE
fix: Make `TemplateID` not required if `TemplateAlias` is specified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.5, 3.6, 3.7, 3.8, 3.9.0-rc.1, pypy3]
+        python: [3.6, 3.7, 3.8, 3.9.0-rc.1, pypy3]
         exclude:
           # pytest bug on PyPy3
           # https://github.com/Stranger6667/postmarker/pull/187/checks?check_run_id=1046220597

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Or you can look at the docs/ directory in the repository.
 Python support
 ==============
 
-Postmarker supports Python 3.5 - 3.9 and PyPy3.
+Postmarker supports Python 3.6 - 3.9 and PyPy3.
 
 Thanks
 ======

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Make ``TemplateID`` not required if ``TemplateAlias`` is specified. `#179`_
+
 `0.16.0`_ - 2020-11-10
 ----------------------
 
@@ -422,6 +427,7 @@ Fixed
 .. _#184: https://github.com/Stranger6667/postmarker/pull/184
 .. _#183: https://github.com/Stranger6667/postmarker/pull/183
 .. _#181: https://github.com/Stranger6667/postmarker/pull/181
+.. _#179: https://github.com/Stranger6667/postmarker/issues/179
 .. _#170: https://github.com/Stranger6667/postmarker/issues/170
 .. _#168: https://github.com/Stranger6667/postmarker/issues/168
 .. _#163: https://github.com/Stranger6667/postmarker/issues/163

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Fixed
 
 - Make ``TemplateID`` not required if ``TemplateAlias`` is specified. `#179`_
 
+Removed
+~~~~~~~
+
+- Support for Python 3.5.
+
 `0.16.0`_ - 2020-11-10
 ----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/src/postmarker/models/emails.py
+++ b/src/postmarker/models/emails.py
@@ -214,6 +214,11 @@ class Email(BaseEmail):
 
 
 class EmailTemplate(BaseEmail):
+    def __init__(self, **kwargs):
+        if kwargs.get("TemplateId") is None and kwargs.get("TemplateAlias") is None:
+            raise ValueError("You need to specify either TemplateId or TemplateAlias")
+        super().__init__(**kwargs)
+
     def send(self):
         return self._manager._send_with_template(**self.as_dict())
 
@@ -352,7 +357,8 @@ class EmailManager(ModelManager):
 
     def send_with_template(
         self,
-        TemplateId,
+        *,
+        TemplateId=None,
         TemplateModel,
         From,
         To,
@@ -443,7 +449,8 @@ class EmailManager(ModelManager):
 
     def EmailTemplate(
         self,
-        TemplateId,
+        *,
+        TemplateId=None,
         TemplateModel,
         From,
         To,

--- a/test/models/test_emails.py
+++ b/test/models/test_emails.py
@@ -206,6 +206,24 @@ class TestSimpleSend:
             "To": "receiver@example.com",
         }
 
+    def test_template_with_alias_only(self, postmark):
+        # It should be possible to specify `TemplateAlias` and not `TemplateId`
+        postmark.emails.EmailTemplate(
+            TemplateAlias="foo",
+            TemplateModel={},
+            From="sender@example.com",
+            To="receiver@example.com",
+        )
+
+    def test_send_with_template_without_alias_and_id(self, postmark):
+        # If there is no `TemplateAlias` and `TemplateId` then it is an error
+        with pytest.raises(ValueError):
+            postmark.emails.send_with_template(
+                TemplateModel={},
+                From="sender@example.com",
+                To="receiver@example.com",
+            )
+
 
 class TestBatchSend:
     def test_email_instance(self, postmark, email, postmark_request):


### PR DESCRIPTION
Fixes #179