### PR TITLE
Adds logic to manage suppressions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Contents:
    django
    tornado
    spamcheck
+   suppression
    webhooks
    testing
    reference

--- a/docs/supression.rst
+++ b/docs/supression.rst
@@ -1,0 +1,77 @@
+.. _supression:
+
+Suppression API
+==============
+
+You can manage Postmark's Suppression lists with a few simple calls:
+
+To view the current suppression list:
+.. code-block:: python
+
+    >>> response = postmark.get_suppressions(stream_id="test")
+    >>> print(response['Suppressions'])
+    {
+      "Suppressions":[
+        {
+          "EmailAddress":"address@wildbit.com",
+          "SuppressionReason":"ManualSuppression",
+          "Origin": "Recipient",
+          "CreatedAt":"2019-12-17T08:58:33-05:00"
+        },
+        {
+          "EmailAddress":"bounce.address@wildbit.com",
+          "SuppressionReason":"HardBounce",
+          "Origin": "Recipient",
+          "CreatedAt":"2019-12-17T08:58:33-05:00"
+        },
+        {
+          "EmailAddress":"spam.complaint.address@wildbit.com",
+          "SuppressionReason":"SpamComplaint",
+          "Origin": "Recipient",
+          "CreatedAt":"2019-12-17T08:58:33-05:00"
+        }
+      ]
+    }
+You can filter this with  "SuppressionReason", "Origin", "todate", "fromdate", and "EmailAddress" lile:
+.. code-block:: python
+
+    >>> response = postmark.get_suppressions(stream_id="test", EmailAddress="address@wildbit.com")
+    >>> print(response['Suppressions'])
+    {
+      "Suppressions":[
+        {
+          "EmailAddress":"address@wildbit.com",
+          "SuppressionReason":"ManualSuppression",
+          "Origin": "Recipient",
+          "CreatedAt":"2019-12-17T08:58:33-05:00"
+        }
+      ]
+    }
+You can add a new suppression with:
+.. code-block:: python
+
+    >>> response = postmark.add_suppressions(stream_id="test", emails=["address@wildbit.com"])
+    >>> print(response['Suppressions'])
+    {
+      "Suppressions":[
+        {
+          "EmailAddress":"good.address@wildbit.com",
+          "Status":"Suppressed",
+          "Message": null
+        },
+      ]
+    }
+You can delete a suppression with:
+.. code-block:: python
+
+    >>> response = postmark.delete_suppressions(stream_id="test", emails=["address@wildbit.com"])
+    >>> print(response['Suppressions'])
+    {
+      "Suppressions":[
+            {
+          "EmailAddress":"address@wildbit.com",
+          "Status":"Deleted",
+          "Message": null
+        }
+      ]
+    }

--- a/src/postmarker/core.py
+++ b/src/postmarker/core.py
@@ -116,6 +116,31 @@ class PostmarkClient:
             raise SpamAssassinError(response["message"])
         return response
 
+    def get_suppressions(self, stream_id, **kwargs):
+        url = DEFAULT_API + f"/message-streams/{stream_id}/suppressions/dump"
+        response = self._call("GET", url, **kwargs)
+        return response
+
+    def add_suppression(self, stream_id, emails):
+        url = DEFAULT_API + f"/message-streams/{stream_id}/suppressions"
+        if type(emails) != list:
+            raise ValueError("emails must be of type list")
+        data = {'Suppressions': []}
+        for email in emails:
+            data['Suppressions'].append({'EmailAddress': email})
+        response = self._call("POST", url, "", data)
+        return response
+
+    def delete_suppression(self, stream_id, emails):
+        url = DEFAULT_API + f"/message-streams/{stream_id}/suppressions/delete"
+        if type(emails) != list:
+            raise ValueError("emails must be of type list")
+        data = {'Suppressions': []}
+        for email in emails:
+            data['Suppressions'].append({'EmailAddress': email})
+        response = self._call("POST", url, "", data)
+        return response
+
     def _call(self, method, root, endpoint, data=None, headers=None, **kwargs):
         default_headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
         if headers:


### PR DESCRIPTION
- Adds calls to list, add, and delete suppression support
- Adds doc pages

I wanted to open this to add some basic support for managing suppressions in Postmark. This just adds a few methods to manage them based on the provided API.

I am not 100% sure how I should test this. Do you have a testing account setup that the test should attempt to list, add, and remove a suppression to? I also am not super familiar with docs, so please let me know if I need to do something else.